### PR TITLE
Detección simple de proximidad y feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .devcontainer/
 .vscode/
 build/
+managed_components/
 sdkconfig*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# Dispositivo de Asistencia para Personas con Debilidad Visual
+# Dispositivo de Asistencia para Personas con Debilidad Visual (DAPDV)
+
+## Conexiones
+
+La siguiente tabla muestra el número de GPIO conectado a cada dispositivo.
+
+| GPIO   | Conexión                                |
+|:------:|:---------------------------------------:|
+| GPIO16 | TF Mini plus UART Tx (color verde)      |
+| GPIO23 | Salida de onda cuadrada hacia el buzzer |

--- a/components/hmi/CMakeLists.txt
+++ b/components/hmi/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "hmi.c"
     INCLUDE_DIRS "include"
+    REQUIRES "driver" "freertos"
 )

--- a/components/hmi/CMakeLists.txt
+++ b/components/hmi/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "hmi.c"
+    INCLUDE_DIRS "include"
+)

--- a/components/hmi/Kconfig.projbuild
+++ b/components/hmi/Kconfig.projbuild
@@ -1,0 +1,8 @@
+menu "Main"
+    config HMI_FEEDBACK_EVENT_QUEUE_LENGTH
+        int
+        default 10
+        prompt "Feedback event queue length"
+        help
+            Maximum number of events that the feedback event queue can hold at a time.
+endmenu

--- a/components/hmi/Kconfig.projbuild
+++ b/components/hmi/Kconfig.projbuild
@@ -1,8 +1,22 @@
-menu "Main"
+menu "HMI"
     config HMI_FEEDBACK_EVENT_QUEUE_LENGTH
         int
         default 10
         prompt "Feedback event queue length"
         help
             Maximum number of events that the feedback event queue can hold at a time.
+
+    config HMI_BUZZER_PIN_NUMBER
+        int
+        default 23
+        prompt "Buzzer digital output GPIO number"
+        help
+            GPIO number of the pin connected to the buzzer output.
+            
+    config HMI_POWER_BUTTON_PIN_NUMBER
+        int
+        default 34
+        prompt "Button input GPIO number"
+        help
+            GPIO number of the pin connected to the power on/off button input.
 endmenu

--- a/components/hmi/hmi.c
+++ b/components/hmi/hmi.c
@@ -1,2 +1,169 @@
 #include "hmi.h"
 
+#define BUZZER_BASE_FREQUENCY_HZ ((uint32_t) 1000)
+
+#define BUZZER_LEDC_SPEED_MODE  (LEDC_LOW_SPEED_MODE)
+#define BUZZER_LEDC_CHANNEL     (LEDC_CHANNEL_0)
+#define BUZZER_LEDC_TIMER       (LEDC_TIMER_0)
+
+#define NUM_NOTES_PER_SEQUENCE  ((uint8_t) 2u)
+
+#define DUTY_NOTE_OFF           ((uint32_t) 0u)
+#define DUTY_NOTE_ON            ((uint32_t) 512u)  /* 50 % duty cycle */
+
+#define NOTE_C4 ((uint32_t) 262u)
+#define NOTE_D4 ((uint32_t) 294u)
+#define NOTE_E4 ((uint32_t) 330u)
+
+/* Configuración para controlar un LED muy raro, que emite sonido en vez de luz. */
+static const ledc_timer_config_t buzzer_pwm_config = {
+    .speed_mode = BUZZER_LEDC_SPEED_MODE,
+    .timer_num = BUZZER_LEDC_TIMER,
+    .freq_hz = BUZZER_BASE_FREQUENCY_HZ,
+    .duty_resolution = LEDC_TIMER_10_BIT,
+    .clk_cfg = LEDC_USE_RC_FAST_CLK,
+};
+
+static const ledc_channel_config_t buzzer_pwm_channel_config = {
+    .speed_mode = BUZZER_LEDC_SPEED_MODE,
+    .channel = BUZZER_LEDC_CHANNEL,
+    .gpio_num = (gpio_num_t) CONFIG_HMI_BUZZER_PIN_NUMBER,
+    .timer_sel = BUZZER_LEDC_TIMER,
+    .intr_type = LEDC_INTR_DISABLE,
+    .duty = 0,
+    .hpoint = 0,
+};
+
+static const char * const TAG = "HMI";
+
+static const uint32_t note_sequences[FEEDBACK_EVENT_MAX - 1][NUM_NOTES_PER_SEQUENCE] = {
+    { NOTE_C4, NOTE_C4 },
+    { BUZZER_BASE_FREQUENCY_HZ, BUZZER_BASE_FREQUENCY_HZ },
+    { BUZZER_BASE_FREQUENCY_HZ, BUZZER_BASE_FREQUENCY_HZ },
+    { BUZZER_BASE_FREQUENCY_HZ, BUZZER_BASE_FREQUENCY_HZ },
+    { NOTE_D4, NOTE_D4 },
+    { NOTE_E4, NOTE_E4 },
+    { BUZZER_BASE_FREQUENCY_HZ, BUZZER_BASE_FREQUENCY_HZ },
+    { BUZZER_BASE_FREQUENCY_HZ, BUZZER_BASE_FREQUENCY_HZ },
+    { BUZZER_BASE_FREQUENCY_HZ, BUZZER_BASE_FREQUENCY_HZ },
+};
+
+static const TickType_t NOTE_DURATION_TICKS = pdMS_TO_TICKS(250);
+static const TickType_t NOTE_PAUSE_TICKS = pdMS_TO_TICKS(250);
+
+// Semáforo para controlar el acceso al buzzer. Sólo puede tomarlo una tarea cuando el buzzer no está reproduciendo un sonido.
+static SemaphoreHandle_t buzzer_semaphore;
+
+esp_err_t hmi_init(void)
+{
+    esp_err_t status;
+
+    status = ESP_OK;
+
+    buzzer_semaphore = xSemaphoreCreateBinary();
+
+    if (NULL != buzzer_semaphore)
+    {
+        if (pdFALSE == xSemaphoreGive(buzzer_semaphore))
+        {
+            ESP_LOGE(TAG, "Failed to initially give buzzer semaphore");
+        }
+    }
+    else
+    {
+        status = ESP_ERR_NO_MEM;
+    }
+
+    if (ESP_OK == status)
+    {
+        status = ledc_timer_config(&buzzer_pwm_config);
+
+        if (ESP_OK != status)
+        {
+            ESP_LOGE(TAG, "Buzzer LEDC timer config error (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        status = ledc_channel_config(&buzzer_pwm_channel_config);
+
+        if (ESP_OK != status)
+        {
+            ESP_LOGE(TAG, "Buzzer LEDC channel config error (%s)", esp_err_to_name(status));
+        }
+    }
+
+    return status;
+}
+
+//TODO: Considerar implementar la secuencia de buzzer usando software timers para no bloquear la tarea que invoca.
+esp_err_t hmi_buzzer_play_feedback_sequence(feedback_event_id_t event_id, TickType_t timeout_ticks)
+{
+    esp_err_t status;
+    uint32_t i;
+
+    status = ESP_OK;
+
+    if (FEEDBACK_EVENT_NONE == event_id || FEEDBACK_EVENT_MAX <= event_id)
+    {
+        status = ESP_ERR_INVALID_ARG;
+    }
+    else if (NULL == buzzer_semaphore)
+    {
+        status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (ESP_OK == status && pdTRUE == xSemaphoreTake(buzzer_semaphore, timeout_ticks))
+    {
+        ESP_LOGI(TAG, "Using buzzer");
+        i = NUM_NOTES_PER_SEQUENCE;
+        while (i--)
+        {
+            if (BUZZER_BASE_FREQUENCY_HZ != note_sequences[((uint8_t) event_id) - 1u][i])
+            {
+                status = ledc_set_freq(BUZZER_LEDC_SPEED_MODE, BUZZER_LEDC_TIMER, note_sequences[((uint8_t) event_id) - 1u][i]);
+
+                if (ESP_OK == status)
+                {
+                    status = ledc_set_duty(BUZZER_LEDC_SPEED_MODE, BUZZER_LEDC_CHANNEL, DUTY_NOTE_ON);
+                }
+
+                if (ESP_OK == status)
+                {
+                    status = ledc_update_duty(BUZZER_LEDC_SPEED_MODE, BUZZER_LEDC_CHANNEL);
+                }
+            }
+
+            vTaskDelay(NOTE_DURATION_TICKS);
+
+            status = ledc_set_duty(BUZZER_LEDC_SPEED_MODE, BUZZER_LEDC_CHANNEL, DUTY_NOTE_OFF);
+
+            if (ESP_OK == status)
+            {
+                status = ledc_update_duty(BUZZER_LEDC_SPEED_MODE, BUZZER_LEDC_CHANNEL);
+            }
+
+            vTaskDelay(NOTE_PAUSE_TICKS);
+        }
+
+        // Regresar el semáforo cuando termina de sonar el buzzer.
+        if (pdFALSE == xSemaphoreGive(buzzer_semaphore))
+        {
+            ESP_LOGE(TAG, "Buzzer xSemaphoreGive failed even when xSemaphoreTake had succeeded");
+        }
+
+        ESP_LOGI(TAG, "Buzzer is free again");
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Buzzer access denied (%s)", esp_err_to_name(status));
+    }
+
+    if (ESP_OK != status)
+    {
+        ESP_LOGW(TAG, "HMI buzzer control error (%s)", esp_err_to_name(status));
+    }
+
+    return status;
+}

--- a/components/hmi/hmi.c
+++ b/components/hmi/hmi.c
@@ -1,0 +1,2 @@
+#include "hmi.h"
+

--- a/components/hmi/include/hmi.h
+++ b/components/hmi/include/hmi.h
@@ -1,0 +1,41 @@
+#ifndef HMI_H_
+#define HMI_H_
+
+#include <stdint.h>
+
+
+typedef enum _feedback_priority_t {
+    FEEDBACK_PRIORITY_LOW,
+    FEEDBACK_PRIORITY_NORMAL,
+    FEEDBACK_PRIORITY_HIGH,
+    FEEDBACK_PRIORITY_MAX,
+} feedback_priority_t;
+
+typedef enum _feedback_event_id_t {
+    FEEDBACK_EVENT_NONE,
+    FEEDBACK_EVENT_STRAIGHT,
+    FEEDBACK_EVENT_LEFT,
+    FEEDBACK_EVENT_RIGHT,
+    FEEDBACK_EVENT_U_TURN,
+    FEEDBACK_EVENT_STOP,
+    FEEDBACK_EVENT_SENSOR_ERROR,
+    FEEDBACK_EVENT_LOW_BATTERY,
+    FEEDBACK_EVENT_PWR_SAVE_ENTER,
+    FEEDBACK_EVENT_PWR_SAVE_EXIT,
+    FEEDBACK_EVENT_MAX,
+} feedback_event_id_t;
+
+typedef enum _feedback_source_t {
+    FEEDBACK_SOURCE_PROXIMITY,
+    FEEDBACK_SOURCE_NAVIGATION,
+    FEEDBACK_SOURCE_OBJECT_DETECT,
+    FEEDBACK_SOURCE_MAX,
+} feedback_source_t;
+
+typedef struct _feedback_event_t {
+    feedback_event_id_t id;
+    feedback_source_t source;
+    feedback_priority_t priority;
+} feedback_event_t;
+
+#endif /* HMI_H_ */

--- a/components/hmi/include/hmi.h
+++ b/components/hmi/include/hmi.h
@@ -3,7 +3,18 @@
 
 #include <stdint.h>
 
+#include <esp_err.h>
+#include <esp_log.h>
 
+#include <driver/gpio.h>
+#include <driver/ledc.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+/**
+ * Public structures and enumerations.
+ */
 typedef enum _feedback_priority_t {
     FEEDBACK_PRIORITY_LOW,
     FEEDBACK_PRIORITY_NORMAL,
@@ -33,9 +44,30 @@ typedef enum _feedback_source_t {
 } feedback_source_t;
 
 typedef struct _feedback_event_t {
-    feedback_event_id_t id;
-    feedback_source_t source;
-    feedback_priority_t priority;
+    feedback_event_id_t id;             /*!< Identificador del tipo de evento de retroalimentación al usuario. */
+    feedback_source_t source;           /*!< Fuente que origina el evento de retroalimentación. */
+    feedback_priority_t priority;       /*!< Prioridad (LOW, NORMAL, HIGH) del evento. */
 } feedback_event_t;
+
+/**
+ * @brief Inicializa los botones y el buzzer del HMI.
+ * 
+ * @return ESP_OK - HMI fue inicializada correctamente.
+ *         Cualquier otro valor - Error durante la inicialización de HMI.
+ */
+esp_err_t hmi_init(void);
+
+
+/**
+ * @brief Activa el buzzer siguiendo la secuencia de tonos correspondiente al tipo de evento.
+ * 
+ * @note Esta función bloquea la tarea de FreeRTOS que la invoca.
+ * 
+ * @param event_id Identificador del evento que selecciona la secuencia.
+ * @param tiemout_ticks El número máximo de ticks que espera a que el buzzer esté libre.
+ * 
+ * @return ESP_OK si la secuencia se reprodució correctamente.
+ */
+esp_err_t hmi_buzzer_play_feedback_sequence(feedback_event_id_t event_id, TickType_t timeout_ticks);
 
 #endif /* HMI_H_ */

--- a/components/imu/CMakeLists.txt
+++ b/components/imu/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "imu.c"
+    INCLUDE_DIRS "include"
+    REQUIRES "driver" "freertos" "mpu6050"    
+)

--- a/components/imu/Kconfig.projbuild
+++ b/components/imu/Kconfig.projbuild
@@ -1,0 +1,29 @@
+menu "IMU"
+    config IMU_SDA_GPIO_NUM
+        int
+        default 21
+        prompt "GPIO connected to the IMU's I2C bus SDA"
+        help
+            GPIO number of the pin connected to the SDA pin of the I2C bus where the IMU is connected.
+
+    config IMU_SCL_GPIO_NUM
+        int
+        default 22
+        prompt "GPIO connected to the IMU's I2C bus SCL"
+        help
+            GPIO number of the pin connected to the SCL pin of the I2C bus where the IMU is connected.
+        
+    config IMU_I2C_BUS_FREQ_HZ
+        int
+        default 100000
+        prompt "IMU I2C bus clock frequency (Hz)"
+        help
+            Frequency in Hz used in I2C communication with the IMU.
+
+    config IMU_INTERRUPT_GPIO_NUM
+        int
+        default 13
+        prompt "IMU interrupt pin GPIO number"
+        help
+            GPIO number connected to the interrupt PIN of the IMU.
+endmenu

--- a/components/imu/idf_component.yml
+++ b/components/imu/idf_component.yml
@@ -1,0 +1,17 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mpu6050: "^1.2.0"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/components/imu/imu.c
+++ b/components/imu/imu.c
@@ -1,0 +1,207 @@
+#include "imu.h"
+
+
+/* Configuración estándar de IMU */
+#define IMU_I2C_NUM I2C_NUM_0
+#define IMU_ACCE_FS ACCE_FS_4G
+#define IMU_GYRO_FS GYRO_FS_250DPS
+
+/* Configuración para que la IMU genere interrupciones */
+#define IMU_INTERRUPT_SOURCES MPU6050_DATA_RDY_INT_BIT
+#define IMU_INTERRUPT_POLARITY INTERRUPT_PIN_ACTIVE_HIGH
+#define IMU_INTERRUPT_GPIO_CONFIG INTERRUPT_PIN_PUSH_PULL
+#define IMU_INTERRUPT_LATCH INTERRUPT_LATCH_50US
+#define IMU_INTERRUPT_CLEAR_BEHAVIOR INTERRUPT_CLEAR_ON_STATUS_READ
+
+static esp_err_t i2c_bus_init(void);
+
+static const char * const TAG = "IMU";
+
+static const mpu6050_int_config_t imu_intr_config = {
+    .interrupt_pin              = CONFIG_IMU_INTERRUPT_GPIO_NUM,
+    .active_level               = IMU_INTERRUPT_POLARITY,
+    .pin_mode                   = IMU_INTERRUPT_GPIO_CONFIG,
+    .interrupt_latch            = IMU_INTERRUPT_LATCH,
+    .interrupt_clear_behavior   = IMU_INTERRUPT_CLEAR_BEHAVIOR,
+};
+
+esp_err_t imu_init(imu_handle_t * const out_handle, const imu_isr_t imu_isr)
+{
+    esp_err_t status;
+    mpu6050_handle_t mpu6050_handle;
+    uint8_t mpu6050_device_id;
+
+    if (NULL != out_handle)
+    {
+        status = ESP_OK;
+    }
+    else
+    {
+        status = ESP_ERR_INVALID_ARG;
+    }
+
+    if (ESP_OK == status)
+    {
+        status = i2c_bus_init();
+
+        if (ESP_OK != status)
+        {
+            ESP_LOGE(TAG, "IMU i2c bus initialization error (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        mpu6050_handle = (imu_handle_t) mpu6050_create(IMU_I2C_NUM, MPU6050_I2C_ADDRESS);
+
+        if (NULL == mpu6050_handle)
+        {
+            status = ESP_ERR_NO_MEM;
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        status = mpu6050_get_deviceid(mpu6050_handle, &mpu6050_device_id);
+
+        if (ESP_OK != status || MPU6050_I2C_ADDRESS != mpu6050_device_id)
+        {
+            ESP_LOGE(TAG, "IMU WHOAMI test failed (%s)", esp_err_to_name(status));
+        }  
+    }
+
+    if (ESP_OK == status)
+    {
+        status = mpu6050_config(mpu6050_handle, IMU_ACCE_FS, IMU_GYRO_FS);
+    }
+
+    if (ESP_OK == status)
+    {
+        status = mpu6050_wake_up(mpu6050_handle);
+    }
+
+    if (NULL != imu_isr && ESP_OK == status)
+    {
+        status = mpu6050_config_interrupts(mpu6050_handle, &imu_intr_config);
+        
+        if (ESP_OK == status)
+        {
+            status = mpu6050_enable_interrupts(mpu6050_handle, IMU_INTERRUPT_SOURCES);
+        }
+
+        if (ESP_OK == status)
+        {
+            status = mpu6050_register_isr(mpu6050_handle, imu_isr);
+        }
+
+        if (ESP_OK != status)
+        {
+            ESP_LOGI(TAG, "IMU isr configuration failed (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        *out_handle = mpu6050_handle;
+    }
+
+    return status;
+}
+
+esp_err_t imu_deinit(imu_handle_t handle)
+{
+    esp_err_t status;
+
+    //TODO
+    status = ESP_OK;
+
+    return status;
+}
+
+esp_err_t imu_read(imu_handle_t handle, imu_value_t * const out_value)
+{
+    mpu6050_acce_value_t mpu6050_acce;
+    mpu6050_gyro_value_t mpu6050_gyro;
+    mpu6050_temp_value_t mpu6050_temp;
+
+    esp_err_t status;
+#if IMU_INTERRUPT_SOURCES == MPU6050_DATA_RDY_INT_BIT
+    uint8_t mpu6050_interrupt_status;
+#endif
+
+    if (NULL != handle && NULL != out_value)
+    {
+        status = ESP_OK;
+    }
+    else
+    {
+        status = ESP_ERR_INVALID_ARG;
+    }
+
+#if IMU_INTERRUPT_SOURCES == MPU6050_DATA_RDY_INT_BIT
+    if (ESP_OK == status)
+    {
+        status = mpu6050_get_interrupt_status((mpu6050_handle_t) handle, &mpu6050_interrupt_status);
+
+        if (ESP_OK == status && 0 == mpu6050_is_data_ready_interrupt(mpu6050_interrupt_status))
+        {
+            // MPU6050 no ha generado la interrupción DATA_READY. Suponer que los valores de los registros son viejos.
+            status = ESP_ERR_TIMEOUT;
+        }
+    }
+#endif
+
+    if (ESP_OK == status)
+    {
+        status = mpu6050_get_acce((mpu6050_handle_t) handle, &mpu6050_acce);
+    }
+
+    if (ESP_OK == status)
+    {
+        status = mpu6050_get_gyro((mpu6050_handle_t) handle, &mpu6050_gyro);
+    }
+
+    if (ESP_OK == status)
+    {
+        status = mpu6050_get_temp((mpu6050_handle_t) handle, &mpu6050_temp);
+    }
+
+    if (ESP_OK == status)
+    {
+        out_value->acceleration.x = mpu6050_acce.acce_x;
+        out_value->acceleration.y = mpu6050_acce.acce_y;
+        out_value->acceleration.z = mpu6050_acce.acce_z;
+
+        out_value->gyro.x = mpu6050_gyro.gyro_x;
+        out_value->gyro.y = mpu6050_gyro.gyro_y;
+        out_value->gyro.z = mpu6050_gyro.gyro_z;
+
+        out_value->temperature = mpu6050_temp.temp;
+    }
+
+    return status;
+}
+
+esp_err_t i2c_bus_init()
+{
+    static const i2c_config_t i2c_bus_config = {
+        .mode = I2C_MODE_MASTER,
+        .master.clk_speed = (uint32_t) CONFIG_IMU_I2C_BUS_FREQ_HZ,
+        .clk_flags = I2C_SCLK_SRC_FLAG_FOR_NOMAL,
+        .sda_io_num = (gpio_num_t) CONFIG_IMU_SDA_GPIO_NUM,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_io_num = (gpio_num_t) CONFIG_IMU_SCL_GPIO_NUM,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+    };
+
+    esp_err_t status;
+
+    status = i2c_param_config(IMU_I2C_NUM, &i2c_bus_config);
+
+    if (ESP_OK == status)
+    {
+        status = i2c_driver_install(IMU_I2C_NUM, i2c_bus_config.mode, 0, 0, 0);
+    }
+
+    return status;
+}

--- a/components/imu/include/imu.h
+++ b/components/imu/include/imu.h
@@ -1,0 +1,70 @@
+#ifndef IMU_H_
+#define IMU_H_
+
+#include <esp_err.h>
+#include <esp_log.h>
+
+#include <driver/i2c.h>
+
+#include <mpu6050.h>
+
+
+typedef struct _imu_value_t {
+    struct {
+        float x;                /*<! Aceleración en el eje x */
+        float y;                /*<! Aceleración en el eje y */
+        float z;                /*<! Aceleración en el eje z */
+    } acceleration;             /*<! Componentes de la aceleración sensada por la IMU */
+    struct {
+        float x;                /*<! Velocidad angular en el eje x */
+        float y;                /*<! Velocidad angular en el eje y */
+        float z;                /*<! Velocidad angular en el eje z */
+    } gyro;
+    float temperature;          /*<! Temperatura de la IMU en grados Celsius */
+} imu_value_t;
+
+typedef mpu6050_handle_t imu_handle_t;
+typedef mpu6050_isr_t imu_isr_t;
+
+/**
+ * @brief Inicializa el bus de comunicación conectado a la IMU y aplica la configuración especificada.
+ * 
+ * @param out_handle referencia a la instancia del driver de IMU inicializado.
+ * @param imu_isr una función ISR que el driver invoca cuando la IMU genera una interrupción.
+ * 
+ * @return - ESP_OK cuando inicializó correctamente la IMU.
+ * @return - ESP_ERR_NO_MEM cuando no hay memoria heap suficiente para inicializar el driver.
+ * @return - ESP_ERR_INVALID_ARG si out_handle es NULL.
+ * @return - ESP_FAIL en caso de algún otro error.
+ */
+esp_err_t imu_init(imu_handle_t * const out_handle, const imu_isr_t imu_isr);
+
+/**
+ * @brief De-inicializa una instancia del driver, libera los recursos asociados.
+ * 
+ * @param handle referencia a la instancia del driver de IMU inicializado.
+ * 
+ * @return - ESP_OK cuando liberó correctamente la instancia del driver.
+ * @return - ESP_ERR_INVALID_ARG si handle es NULL.
+ * @return - ESP_FAIL en caso de algún otro error.
+ */
+esp_err_t imu_deinit(imu_handle_t handle);
+
+/**
+ * @brief Lee los registros de datos de la IMU y los regresa en forma de imu_value_t.
+ * 
+ * @note Si la interrupción DATA_READY está activada, imu_read() primero revisa si
+ *       la IMU ha generado esa interrupción. Si no es así, la lectura falla, indicando 
+ *       que no hay datos nuevos en los registros.
+ * 
+ * @param handle referencia a la instancia del driver de IMU.
+ * @param out_value referencia en la que almacenará los valores de los registros de la IMU.
+ * 
+ * @return - ESP_OK cuando leyó y almacenó correctamente los valores.
+ * @return - ESP_ERR_TIMEOUT cuando no hay datos nuevos disponibles.
+ * @return - ESP_ERR_INVALID_ARG cuando handle u out_value es NULL.
+ * @return - ESP_FAIL en caso de algún otro error.
+ */
+esp_err_t imu_read(imu_handle_t handle, imu_value_t * const out_value);
+
+#endif /* IMU_H_ */

--- a/components/tf_mini_parser/CMakeLists.txt
+++ b/components/tf_mini_parser/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "tf_mini_parser.c"
     INCLUDE_DIRS "include"
-    REQUIRES "driver" "esp_event" "freertos"
+    REQUIRES "driver" "esp_event" "freertos" "iqmath"
 )

--- a/components/tf_mini_parser/idf_component.yml
+++ b/components/tf_mini_parser/idf_component.yml
@@ -1,0 +1,17 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/iqmath: "^1.11.0"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/components/tf_mini_parser/include/tf_mini_parser.h
+++ b/components/tf_mini_parser/include/tf_mini_parser.h
@@ -8,6 +8,8 @@
 #include <driver/gpio.h>
 #include <driver/uart.h>
 
+#include <IQmathLib.h>
+
 typedef enum _tf_mini_event_id_t {
     TF_MINI_OK,
     TF_MINI_ERR_LOW_STRENGTH,
@@ -18,9 +20,9 @@ typedef enum _tf_mini_event_id_t {
 } tf_mini_event_id_t;
 
 typedef struct _tf_mini_df_t {
-    uint16_t distance_cm;               /*!< Distancia detectada en centímetros. */
+    _iq15 distance_meters;              /*!< Distancia detectada en metros, con precisión de 0.01 m. */
     uint16_t signal_strength;           /*!< Fuerza de la señal detectada. Si está fuera de rango, distance_cm tiene valor anormal. */
-    float temperature_deg_c;            /*!< Temperatura interna del sensor en grados celsius. */
+    _iq15 temperature_deg_c;            /*!< Temperatura interna del sensor en grados celsius. */
     tf_mini_event_id_t event_id;        /*!< Clasificación del dataframe según los valores de los campos. */
 } tf_mini_df_t;
 

--- a/components/tf_mini_parser/tf_mini_parser.c
+++ b/components/tf_mini_parser/tf_mini_parser.c
@@ -319,7 +319,7 @@ tf_mini_df_t * parse_tf_mini_df(const uint8_t * const header, const uint8_t * co
                     // Saturación a causa de la luz en el entorno.
                     parsed_df->event_id = TF_MINI_ERR_AMB_LIGHT_SATURATION;
                 }
-                else if (OP_TEMPERATURE_MIN_C > parsed_df->temperature_deg_c || OP_TEMPERATURE_MAX_C < parsed_df->temperature_deg_c)
+                else if (OP_TEMPERATURE_MIN_C >= parsed_df->temperature_deg_c || OP_TEMPERATURE_MAX_C <= parsed_df->temperature_deg_c)
                 {
                     // La temperatura del sensor está fuera del rango de operación.
                     parsed_df->event_id = TF_MINI_ERR_TEMPERATURE;

--- a/components/tf_mini_parser/tf_mini_parser.c
+++ b/components/tf_mini_parser/tf_mini_parser.c
@@ -16,8 +16,8 @@ static const uint16_t LOW_STRENGTH_THRESHOLD = 100u;
 static const uint16_t SAT_STRENGTH_THRESHOLD = 0xFFFFu;
 
 // Umbrales de temperatura de operación.
-static const uint16_t OP_TEMPERATURE_MIN_C = 0u;
-static const uint16_t OP_TEMPERATURE_MAX_C = 70u;
+static const _iq15 OP_TEMPERATURE_MIN_C = _IQ15(-20.0f);
+static const _iq15 OP_TEMPERATURE_MAX_C = _IQ15(60.0f);
 
 typedef struct {
     uart_port_t uart_port;
@@ -273,6 +273,7 @@ void tf_mini_parser_task(void * pvParameters)
 tf_mini_df_t * parse_tf_mini_df(const uint8_t * const header, const uint8_t * const buf)
 {
     tf_mini_df_t * parsed_df;
+    uint16_t distance_cm;
     uint8_t i;
     uint8_t checksum;
 
@@ -294,25 +295,26 @@ tf_mini_df_t * parse_tf_mini_df(const uint8_t * const header, const uint8_t * co
 
             if (NULL != parsed_df)
             {
+                distance_cm = (((uint16_t) buf[1]) << 8u) | (uint16_t) buf[0];
                 *parsed_df = (tf_mini_df_t) {
-                    .distance_cm = (((uint16_t) buf[1]) << 8u) | (uint16_t) buf[0],
+                    .distance_meters = _IQ15div(_IQ15(distance_cm), _IQ15(100)),
                     .signal_strength = (((uint16_t) buf[3]) << 8u) | (uint16_t) buf[2],
-                    .temperature_deg_c = (((((uint16_t) buf[5]) << 8u) | (uint16_t) buf[4]) / 8) - 256,
+                    .temperature_deg_c = _IQ15((((((uint16_t) buf[5]) << 8u) | (uint16_t) buf[4]) / 8) - 256),
                     .event_id = TF_MINI_OK,
                 };
 
                 // Identificar si alguno de los valores es anormal.
-                if (LOW_STRENGTH_DISTANCE == parsed_df->distance_cm || LOW_STRENGTH_THRESHOLD > parsed_df->signal_strength)
+                if (LOW_STRENGTH_DISTANCE == distance_cm || LOW_STRENGTH_THRESHOLD > parsed_df->signal_strength)
                 {
                     // La fuerza de la señal es baja.
                     parsed_df->event_id = TF_MINI_ERR_LOW_STRENGTH;
                 }
-                else if (SAT_STRENGTH_DISTANCE == parsed_df->distance_cm || SAT_STRENGTH_THRESHOLD == parsed_df->signal_strength)
+                else if (SAT_STRENGTH_DISTANCE == distance_cm || SAT_STRENGTH_THRESHOLD == parsed_df->signal_strength)
                 {
                     // Fuerza de la señal está saturada.
                     parsed_df->event_id = TF_MINI_ERR_STRENGTH_SATURATION;
                 }
-                else if (AMB_LIGHT_SAT_DISTANCE == parsed_df->distance_cm)
+                else if (AMB_LIGHT_SAT_DISTANCE == distance_cm)
                 {
                     // Saturación a causa de la luz en el entorno.
                     parsed_df->event_id = TF_MINI_ERR_AMB_LIGHT_SATURATION;

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -10,13 +10,25 @@ dependencies:
       registry_url: https://components.espressif.com/
       type: service
     version: 1.11.0
+  espressif/mpu6050:
+    component_hash: d69219ccb141372b863c511749ffbeab28417ac71c205d7ed7030c308e1b6832
+    dependencies:
+    - name: idf
+      registry_url: https://components.espressif.com
+      require: private
+      version: '>=4.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.2.0
   idf:
     source:
       type: idf
     version: 5.2.3
 direct_dependencies:
 - espressif/iqmath
+- espressif/mpu6050
 - idf
-manifest_hash: 57f8cabf86bdfea46e7dce3af2b7b0e5e00f29765270d57771c321f2c5556ac2
+manifest_hash: 041c12130e19269233e7cae37b57a6f8ac2a26a048db5043a8ecd0ae3481da28
 target: esp32
 version: 2.0.0

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,0 +1,22 @@
+dependencies:
+  espressif/iqmath:
+    component_hash: 407d5bc3fd358a73d2b09982918ab508b4e804cc547942c5979d226be86b7e75
+    dependencies:
+    - name: idf
+      registry_url: https://components.espressif.com
+      require: private
+      version: '>=4.4'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.11.0
+  idf:
+    source:
+      type: idf
+    version: 5.2.3
+direct_dependencies:
+- espressif/iqmath
+- idf
+manifest_hash: 57f8cabf86bdfea46e7dce3af2b7b0e5e00f29765270d57771c321f2c5556ac2
+target: esp32
+version: 2.0.0

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES "tf_mini_parser" "hmi"
+    REQUIRES "tf_mini_parser" "hmi" "imu"
 )

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES "tf_mini_parser"
+    REQUIRES "tf_mini_parser" "hmi"
 )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,17 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/iqmath: "^1.11.0"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/main/main.c
+++ b/main/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 
+#include <esp_err.h>
 #include <esp_log.h>
 
 #include <driver/gpio.h>
@@ -10,27 +11,338 @@
 
 #include <IQmathLib.h>
 
+#include "hmi.h"
 #include "tf_mini_parser.h"
+
+typedef struct _proximity_range_update_t {
+    int8_t index_change;
+    _iq15 distance_meters;
+} proximity_range_update_t;
 
 static const char * const TAG = "MAIN";
 
-static const size_t TF_MINI_DATA_QUEUE_LEN = 20;
-static const _iq15 TF_MINI_DIST_MIN_M = _IQ15(0.1f);
-static const _iq15 TF_MINI_DIST_MAX_M = _IQ15(12);
+static const UBaseType_t TF_MINI_DATA_QUEUE_LEN = 20;
 
-static const uint8_t DIST_SENSOR_VALID_FG = 0x01u;
+static const UBaseType_t PROXIMITY_UPDATE_QUEUE_LEN = 3;
+static const int8_t PROXIMITY_RANGE_INTERVAL_COUNT = 9;
+
+static tf_mini_parser_config_t distance_sensor_config = (tf_mini_parser_config_t) {
+    .uart = {
+        .port = UART_NUM_2,
+        .bit_rate = 115200,
+        .rx_pin = GPIO_NUM_16,
+        .word_length = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+    },
+    .event_queue_length = 20,
+    .data_queue_handle = NULL,
+};
 
 static void distance_sensor_task(void * pvParameters);
+static void proximity_task(void * pvParameters);
+static void hmi_task(void * pvParameters);
+
+static QueueHandle_t feedback_event_queue;
 
 void app_main(void)
 {
     esp_err_t status;
     BaseType_t result;
-    QueueHandle_t distance_sensor_data_queue;
-    tf_mini_handle_t tf_mini_handle;
-    tf_mini_parser_config_t tf_mini_cfg;
+    QueueHandle_t proximity_update_queue;
 
     status = ESP_OK;
+
+    if (ESP_OK == status)
+    {
+        feedback_event_queue = xQueueCreate(CONFIG_HMI_FEEDBACK_EVENT_QUEUE_LENGTH, sizeof(feedback_event_t *));
+
+        if (NULL == feedback_event_queue)
+        {
+            status = ESP_ERR_NO_MEM;
+            ESP_LOGW(TAG, "Create feedback event queue fail (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        proximity_update_queue = xQueueCreate(PROXIMITY_UPDATE_QUEUE_LEN, sizeof(proximity_range_update_t *));
+
+        if (NULL == proximity_update_queue)
+        {
+            status = ESP_ERR_NO_MEM;
+            ESP_LOGW(TAG, "Create proximity update queue fail (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        result = xTaskCreate(proximity_task, "proximity_task", 2048, (void *) proximity_update_queue, 5, NULL);
+
+        if (pdPASS != result)
+        {
+            status = ESP_FAIL;
+            ESP_LOGE(TAG, "Proximity task init error (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        result = xTaskCreate(distance_sensor_task, "dist_sensor_task", 2048, (void *) proximity_update_queue, 5, NULL);
+
+        if (pdPASS != result)
+        {
+            status = ESP_FAIL;
+            ESP_LOGE(TAG, "Distance sensor task init error (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        result = xTaskCreate(hmi_task, "hmi_task", 2048, NULL, 6, NULL);
+
+        if (pdPASS != result)
+        {
+            status = ESP_FAIL;
+            ESP_LOGE(TAG, "HMI feedback task init error (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        ESP_LOGI(TAG, "Initialization complete");
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Main initialization error (%s)", esp_err_to_name(status));
+    }
+}
+
+void hmi_task(void * pvParameters)
+{
+    static const TickType_t FEEDBACK_RECEIVE_TIMEOUT_TICKS = pdMS_TO_TICKS(1000u);
+
+    BaseType_t result;
+    feedback_event_t * feedback_event;
+
+    if (NULL == feedback_event_queue)
+    {
+        ESP_LOGE(TAG, "HMI task feedback event queue not initialized");
+        vTaskDelete(NULL);
+    }
+
+    while (1)
+    {
+        result = xQueueReceive(feedback_event_queue, (void * const) &feedback_event, FEEDBACK_RECEIVE_TIMEOUT_TICKS);
+
+        if (pdTRUE == result)
+        {
+            if (NULL != feedback_event)
+            {
+                ESP_LOGI(TAG, "HMI feedback event - ID = %hhu, src = %hhu, priority = %hhu", (uint8_t) feedback_event->id, (uint8_t) feedback_event->source, (uint8_t) feedback_event->priority);
+
+                //TODO: Drive feedback device according to feedback event.
+
+                free(feedback_event);
+                feedback_event = NULL;
+            }
+            else
+            {
+                ESP_LOGW(TAG, "HMI task received feedback event with no payload");
+            }
+        }
+        else
+        {
+            ESP_LOGD(TAG, "HMI task received no feedback events");
+        }
+    }
+
+    vTaskDelete(NULL);
+}
+
+void proximity_task(void * pvParameters)
+{
+    static const TickType_t RECEIVE_RANGE_UPDATE_TIMEOUT = pdMS_TO_TICKS(100);
+    static const _iq15 FAR_COLLISION_ALERT_DISTANCE_M = _IQ15(1.0f);
+    static const _iq15 NEAR_COLLISION_ALERT_DISTANCE_M = _IQ15(0.5f);
+
+    QueueHandle_t proximity_range_update_queue;
+    proximity_range_update_t * proximity_range_update;
+
+    int8_t cursor;
+    _iq15 * proximity_range;
+
+    esp_err_t status;
+    BaseType_t queue_result;
+    UBaseType_t notify_level;
+
+    feedback_event_t * feedback_event;
+
+    status = ESP_OK;
+    cursor = 4u;
+
+    if (NULL != pvParameters)
+    {
+        proximity_range_update_queue = (QueueHandle_t) pvParameters;
+    }
+    else
+    {
+        proximity_range_update_queue = NULL;
+        status = ESP_ERR_INVALID_ARG;
+    }
+
+    if (ESP_OK == status)
+    {
+        proximity_range = (_iq15 *) malloc(PROXIMITY_RANGE_INTERVAL_COUNT * sizeof(_iq15));
+
+        if (NULL == proximity_range)
+        {
+            status = ESP_ERR_NO_MEM;
+        }
+    }
+
+    if (ESP_OK != status)
+    {
+        ESP_LOGE(TAG, "Proximity task initialization failed (%s)", esp_err_to_name(status));
+        vTaskDelete(NULL);
+    }
+
+    notify_level = 0u;
+
+    while (1)
+    {
+        queue_result = xQueueReceive(proximity_range_update_queue, (void *) &proximity_range_update, RECEIVE_RANGE_UPDATE_TIMEOUT);
+
+        if (pdPASS == queue_result && NULL != proximity_range_update)
+        {
+            cursor += proximity_range_update->index_change;
+
+            if (0 > cursor)
+            {
+                cursor = 0;
+            }
+            else if (PROXIMITY_RANGE_INTERVAL_COUNT <= cursor)
+            {
+                cursor = PROXIMITY_RANGE_INTERVAL_COUNT - 1;
+            }
+
+            proximity_range[cursor] = proximity_range_update->distance_meters;
+
+            free(proximity_range_update);
+            proximity_range_update = NULL;
+
+            if (FAR_COLLISION_ALERT_DISTANCE_M >= proximity_range[4])
+            {
+                if (NEAR_COLLISION_ALERT_DISTANCE_M >= proximity_range[4])
+                {
+                    if (2u > notify_level)
+                    {
+                        feedback_event = (feedback_event_t *) malloc(sizeof(feedback_event_t));
+
+                        if (NULL != feedback_event)
+                        {
+                            *feedback_event = (feedback_event_t) {
+                                .id = FEEDBACK_EVENT_STOP,
+                                .source = FEEDBACK_SOURCE_PROXIMITY,
+                                .priority = FEEDBACK_PRIORITY_HIGH,
+                            };
+
+                            queue_result = xQueueSendToBack(feedback_event_queue, (void *) &feedback_event, pdMS_TO_TICKS(100));
+                            feedback_event = NULL;
+
+                            if (pdTRUE == queue_result)
+                            {
+                                notify_level = 2u;
+                            }
+                            else
+                            {
+                                ESP_LOGW(TAG, "Proximity feedback not sent (QUEUE_FULL)");
+                            }
+                        }
+                        else
+                        {
+                            ESP_LOGW(TAG, "Proximity feedback event allocation fail (ESP_ERR_NO_MEM)");
+                        }
+                    }
+                }
+                else if (2u == notify_level)
+                {
+                    notify_level = 1u;
+                }
+                else if (1u > notify_level)
+                {
+                    feedback_event = (feedback_event_t *) malloc(sizeof(feedback_event_t));
+
+                    if (NULL != feedback_event)
+                    {
+                        *feedback_event = (feedback_event_t) {
+                            .id = FEEDBACK_EVENT_STOP,
+                            .source = FEEDBACK_SOURCE_PROXIMITY,
+                            .priority = FEEDBACK_PRIORITY_NORMAL,
+                        };
+
+                        queue_result = xQueueSendToBack(feedback_event_queue, (void *) &feedback_event, pdMS_TO_TICKS(100));
+                        feedback_event = NULL;
+
+                        if (pdTRUE == queue_result)
+                        {
+                            notify_level = 1u;
+                        }
+                        else
+                        {
+                            ESP_LOGW(TAG, "Proximity feedback not sent (QUEUE_FULL)");
+                        }
+                    }
+                    else
+                    {
+                        ESP_LOGW(TAG, "Proximity feedback event allocation fail (ESP_ERR_NO_MEM)");
+                    }
+                }
+            }
+            else
+            {
+                notify_level = 0u;
+            }
+        }
+    }
+
+    vTaskDelete(NULL);
+}
+
+void distance_sensor_task(void * pvParameters)
+{
+    static const TickType_t SEND_PROXIMITY_UPDATE_TIMEOUT_TICKS = pdMS_TO_TICKS(10);
+    static const _iq15 TF_MINI_DIST_MIN_M = _IQ15(0.1f);
+    static const _iq15 TF_MINI_DIST_MAX_M = _IQ15(12);
+
+    static const uint8_t DIST_SENSOR_VALID_FG = 0x01u;
+
+    esp_err_t status;
+    BaseType_t queue_result;
+
+    QueueHandle_t distance_sensor_data_queue;
+    QueueHandle_t proximity_range_update_queue;
+
+    tf_mini_handle_t tf_mini_handle;
+    tf_mini_df_t * data_frame;
+    uint8_t valid_data_frames;
+
+    proximity_range_update_t * proximity_range_update;
+    
+    char dist_str[12u];
+    char temperature_str[12u];
+
+    status = ESP_OK;
+
+    if (NULL != pvParameters)
+    {
+        proximity_range_update_queue = (QueueHandle_t) pvParameters;
+    }
+    else
+    {
+        status = ESP_ERR_INVALID_ARG;
+        proximity_range_update_queue = NULL;
+    }
 
     if (ESP_OK == status)
     {
@@ -45,64 +357,14 @@ void app_main(void)
 
     if (ESP_OK == status)
     {
-        tf_mini_cfg = (tf_mini_parser_config_t) {
-            .uart = {
-                .port = UART_NUM_2,
-                .bit_rate = 115200,
-                .rx_pin = GPIO_NUM_16,
-                .word_length = UART_DATA_8_BITS,
-                .parity = UART_PARITY_DISABLE,
-                .stop_bits = UART_STOP_BITS_1,
-            },
-            .event_queue_length = 20,
-            .data_queue_handle = distance_sensor_data_queue
-        };
-
-        status = tf_mini_parser_init(&tf_mini_handle, &tf_mini_cfg);
-
-        if (ESP_OK == status)
-        {
-            ESP_LOGI(TAG, "TF MINI parser init OK");
-        }
-        else
-        {
-            ESP_LOGE(TAG, "TF MINI parser init error (%s)", esp_err_to_name(status));
-        }
+        distance_sensor_config.data_queue_handle = distance_sensor_data_queue;
+        status = tf_mini_parser_init(&tf_mini_handle, &distance_sensor_config);
     }
 
-    if (ESP_OK == status)
+    if (ESP_OK != status)
     {
-        result = xTaskCreate(distance_sensor_task, "consumer_task", 2048, (void *) &distance_sensor_data_queue, 5, NULL);
-
-        if (pdPASS == result)
-        {
-            ESP_LOGI(TAG, "TF mini consumer task init OK");
-        }
-        else
-        {
-            status = ESP_FAIL;
-            ESP_LOGE(TAG, "TF mini consumer task init error (%s)", esp_err_to_name(status));
-        }
-    }
-}
-
-void distance_sensor_task(void * pvParameters)
-{
-    QueueHandle_t distance_sensor_data_queue;
-    BaseType_t queue_result;
-    tf_mini_df_t * data_frame;
-    uint8_t valid_data_frames;
-
-    char dist_str[12u];
-    char temperature_str[12u];
-
-    if (NULL != pvParameters)
-    {
-        distance_sensor_data_queue = *((QueueHandle_t *) pvParameters);
-    }
-    else
-    {
-        distance_sensor_data_queue = NULL;
+        ESP_LOGE(TAG, "Distance sensor task initialization failed (%s)", esp_err_to_name(status));
+        vTaskDelete(NULL);
     }
 
     while (1)
@@ -153,9 +415,31 @@ void distance_sensor_task(void * pvParameters)
             ESP_LOGE(TAG, "TF mini NO DATA");
         }
 
-        if (DIST_SENSOR_VALID_FG & valid_data_frames)
+        if (NULL != data_frame)
         {
-            ESP_LOGI(TAG, "TF mini DF { dist = %s m, strength = %hu, temp = %s deg C}", dist_str, data_frame->signal_strength, temperature_str);
+            if (DIST_SENSOR_VALID_FG & valid_data_frames)
+            {
+                ESP_LOGD(TAG, "TF mini DF { dist = %s m, strength = %hu, temp = %s deg C}", dist_str, data_frame->signal_strength, temperature_str);
+            }
+
+            //TODO: Only send update when one of these conditions is met: 1) change of distance 2) change of angle 3) sensor error.
+            proximity_range_update = (proximity_range_update_t *) malloc(sizeof(proximity_range_update_t));
+
+            if (NULL != proximity_range_update)
+            {
+                *proximity_range_update = (proximity_range_update_t) {
+                    .index_change = 0,
+                    .distance_meters = data_frame->distance_meters,
+                };
+
+                queue_result = xQueueSendToBack(proximity_range_update_queue, (void *) &proximity_range_update, SEND_PROXIMITY_UPDATE_TIMEOUT_TICKS);
+                proximity_range_update = NULL;
+
+                if (pdFAIL == queue_result)
+                {
+                    ESP_LOGW(TAG, "Send proximity update fail (QUEUE_FULL)");
+                }
+            }
         }
 
         if (NULL != data_frame)

--- a/main/main.c
+++ b/main/main.c
@@ -1,29 +1,32 @@
 #include <stdio.h>
 
+#include <esp_log.h>
+
+#include <driver/gpio.h>
+
 #include <freertos/FreeRTOS.h>
-// #include <freertos/task.h>
+#include <freertos/task.h>
 #include <freertos/queue.h>
 
-#include <esp_log.h>
+#include <IQmathLib.h>
 
 #include "tf_mini_parser.h"
 
 static const char * const TAG = "MAIN";
 
 static const size_t TF_MINI_DATA_QUEUE_LEN = 20;
-static const uint16_t TF_MINI_DIST_MIN_CM = 10u;
-static const uint16_t TF_MINI_DIST_MAX_CM = 1200u;
+static const _iq15 TF_MINI_DIST_MIN_M = _IQ15(0.1f);
+static const _iq15 TF_MINI_DIST_MAX_M = _IQ15(12);
 
 static const uint8_t DIST_SENSOR_VALID_FG = 0x01u;
 
-static QueueHandle_t tf_mini_data_queue;
-
-static void test_consumer_task(void * pvParameters);
+static void distance_sensor_task(void * pvParameters);
 
 void app_main(void)
 {
     esp_err_t status;
     BaseType_t result;
+    QueueHandle_t distance_sensor_data_queue;
     tf_mini_handle_t tf_mini_handle;
     tf_mini_parser_config_t tf_mini_cfg;
 
@@ -31,11 +34,11 @@ void app_main(void)
 
     if (ESP_OK == status)
     {
-        tf_mini_data_queue = xQueueCreate(TF_MINI_DATA_QUEUE_LEN, sizeof(tf_mini_df_t * ));
+        distance_sensor_data_queue = xQueueCreate(TF_MINI_DATA_QUEUE_LEN, sizeof(tf_mini_df_t *));
 
-        if (NULL == tf_mini_data_queue)
+        if (NULL == distance_sensor_data_queue)
         {
-            ESP_LOGW(TAG, "Create TF MINI data queue fail, no memory");
+            ESP_LOGW(TAG, "Create distance sensor data queue fail, no memory");
             status = ESP_ERR_NO_MEM;
         }
     }
@@ -46,13 +49,13 @@ void app_main(void)
             .uart = {
                 .port = UART_NUM_2,
                 .bit_rate = 115200,
-                .rx_pin = 16,
+                .rx_pin = GPIO_NUM_16,
                 .word_length = UART_DATA_8_BITS,
                 .parity = UART_PARITY_DISABLE,
                 .stop_bits = UART_STOP_BITS_1,
             },
             .event_queue_length = 20,
-            .data_queue_handle = tf_mini_data_queue
+            .data_queue_handle = distance_sensor_data_queue
         };
 
         status = tf_mini_parser_init(&tf_mini_handle, &tf_mini_cfg);
@@ -69,7 +72,7 @@ void app_main(void)
 
     if (ESP_OK == status)
     {
-        result = xTaskCreate(test_consumer_task, "consumer_task", 2048, NULL, 5, NULL);
+        result = xTaskCreate(distance_sensor_task, "consumer_task", 2048, (void *) &distance_sensor_data_queue, 5, NULL);
 
         if (pdPASS == result)
         {
@@ -83,29 +86,45 @@ void app_main(void)
     }
 }
 
-void test_consumer_task(void * pvParameters)
+void distance_sensor_task(void * pvParameters)
 {
+    QueueHandle_t distance_sensor_data_queue;
     BaseType_t queue_result;
     tf_mini_df_t * data_frame;
     uint8_t valid_data_frames;
 
+    char dist_str[12u];
+    char temperature_str[12u];
+
+    if (NULL != pvParameters)
+    {
+        distance_sensor_data_queue = *((QueueHandle_t *) pvParameters);
+    }
+    else
+    {
+        distance_sensor_data_queue = NULL;
+    }
+
     while (1)
     {
         valid_data_frames = 0u;
-        queue_result = xQueueReceive(tf_mini_data_queue, (void *) &data_frame, (TickType_t) pdMS_TO_TICKS(100));
+        queue_result = xQueueReceive(distance_sensor_data_queue, (void *) &data_frame, (TickType_t) pdMS_TO_TICKS(100));
     
         if (pdPASS == queue_result && NULL != data_frame)
         {
             switch (data_frame->event_id)
             {
             case TF_MINI_OK:
-                if (TF_MINI_DIST_MIN_CM > data_frame->distance_cm)
+                _IQ15toa(dist_str, "%2.2f", data_frame->distance_meters);
+                _IQ15toa(temperature_str, "%2.1f", data_frame->temperature_deg_c);
+
+                if (TF_MINI_DIST_MIN_M > data_frame->distance_meters)
                 {
-                    ESP_LOGW(TAG, "TF mini (TOO CLOSE, dist = %hu cm)", data_frame->distance_cm);
+                    ESP_LOGW(TAG, "TF mini (TOO CLOSE, dist = %s m)", dist_str);
                 }
-                else if (TF_MINI_DIST_MAX_CM < data_frame->distance_cm)
+                else if (TF_MINI_DIST_MAX_M < data_frame->distance_meters)
                 {
-                    ESP_LOGW(TAG, "TF mini (TOO FAR, dist = %hu cm)", data_frame->distance_cm);
+                    ESP_LOGW(TAG, "TF mini (TOO FAR, dist = %s m)", dist_str);
                 }
                 else
                 {
@@ -136,15 +155,14 @@ void test_consumer_task(void * pvParameters)
 
         if (DIST_SENSOR_VALID_FG & valid_data_frames)
         {
-            ESP_LOGI(TAG, "TF mini DF { dist = %hu cm, strength = %hu, temp = %.2f deg C}", data_frame->distance_cm, data_frame->signal_strength, data_frame->temperature_deg_c);
+            ESP_LOGI(TAG, "TF mini DF { dist = %s m, strength = %hu, temp = %s deg C}", dist_str, data_frame->signal_strength, temperature_str);
         }
 
         if (NULL != data_frame)
         {
             free(data_frame);
+            data_frame = NULL;
         }
-
-        data_frame = NULL;
     }
 
     vTaskDelete(NULL);


### PR DESCRIPTION
Con los cambios incluidos:

- Envía eventos de feedback al usuario según la distancia detectada por el LIDAR, o en condiciones de erorr de sensor.
- Lee los valores de la IMU (no los usa todavía).
- Hay un mock para la tarea de detección de objetos (sólo usa dos casos: detecta un objeto, o no detecta un objeto).
- La tarea de feedback recibe los eventos y usa el driver del buzzer para reproducir una secuencia de tonos. Tiene limitaciones:
    - No distingue las proridades de los eventos.
    - El uso del buzzer bloquea la tarea de feedback.
    - No tiene tiempo mínimo de pausa requerida entre dos secuencias de tonos (dos secuencias se pueden confundir).

Faltan pruebas más detalladas y de integración.