### PR TITLE
Entrar en modo de sueño profundo si usuario presiona botón o la batería está en voltaje crítico

### DIFF
--- a/components/battery_monitor/CMakeLists.txt
+++ b/components/battery_monitor/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "battery_monitor.c"
+    INCLUDE_DIRS "include"
+    REQUIRES "esp_adc" "freertos" "power_save" "hmi"
+)

--- a/components/battery_monitor/Kconfig.projbuild
+++ b/components/battery_monitor/Kconfig.projbuild
@@ -1,0 +1,25 @@
+menu "Battery monitor"
+    config BATTERY_MON_LOW_BATTERY_THRESHOLD_MV
+        int
+        default 3500
+        prompt "Battery low state threshold (mV)"
+        help
+            Under this threshold, the battery monitor considers the battery voltage as LOW.
+    config BATTERY_MON_CRITICAL_BATTERY_THRESHOLD_MV
+        int
+        default 3200
+        prompt "Battery critical sate threshold (mV)"
+        help
+            Under this voltage threshold, the battery montiro considers the battery voltage as CRITICAL.
+    config BATTERY_MONITOR_SAMPLE_PERIOD_MS
+        int
+        default 1000
+        prompt "Battery monitor ADC sample period (milliseconds)"
+        help
+            The number of milliseconds between two battery monitor samples.
+    config BATTERY_MON_ADC_GPIO_NUM
+        int
+        default 35
+        prompt "GPIO number of the PIN connected to the battery voltage analog output"
+
+endmenu

--- a/components/battery_monitor/battery_monitor.c
+++ b/components/battery_monitor/battery_monitor.c
@@ -1,0 +1,240 @@
+#include "battery_monitor.h"
+
+#define CAN_ENTER_DEEP_SLEEP_ON_LOW_BATTERY (0)
+
+#define BATTERY_MONITOR_ADC_CONVERSION_MODE ADC_CONV_SINGLE_UNIT_1
+#define BATTERY_MONITOR_ADC_OUTPUT_FORMAT ADC_DIGI_OUTPUT_FORMAT_TYPE1
+#define BATTERY_MONITOR_ADC_ATTENUATION ADC_ATTEN_DB_0
+#define BATTERY_MONITOR_ADC_BIT_WIDTH SOC_ADC_DIGI_MAX_BITWIDTH
+
+static void battery_monitor_timer_callback(TimerHandle_t timer); 
+
+static bool adc_calibration_init(adc_unit_t unit_id, adc_channel_t channel, adc_atten_t attenuation, adc_cali_handle_t * out_calibration_handle);
+
+static const char * const TAG = "BATTERY_MON";
+
+static bool adc_is_calibrated;
+static adc_oneshot_unit_handle_t adc_handle; 
+static adc_channel_t battery_monitor_adc_channel;
+static adc_cali_handle_t battery_monitor_adc_calibration_handle;
+
+static TimerHandle_t battery_monitor_timer;
+
+static QueueHandle_t feedback_event_queue;
+
+esp_err_t battery_monitor_init(const QueueHandle_t feedback_event_queue_handle)
+{
+    static const adc_oneshot_chan_cfg_t battery_monitor_adc_config = {
+        .atten = BATTERY_MONITOR_ADC_ATTENUATION,
+        .bitwidth = BATTERY_MONITOR_ADC_BIT_WIDTH,
+    };
+
+    esp_err_t status;
+    BaseType_t result;
+    adc_oneshot_unit_init_cfg_t adc1_init_config;
+
+    status = ESP_OK;
+    adc_handle = NULL;
+
+    if (ESP_OK == status)
+    {
+        status = adc_oneshot_io_to_channel(CONFIG_BATTERY_MON_ADC_GPIO_NUM, &adc1_init_config.unit_id, &battery_monitor_adc_channel);
+
+        if (ESP_ERR_NOT_FOUND == status)
+        {
+            ESP_LOGE(TAG, "ADC IO to channel conversion fail (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        adc1_init_config.clk_src = 0;
+        status = adc_oneshot_new_unit(&adc1_init_config, &adc_handle);
+    }
+
+    if (ESP_OK == status)
+    {
+        ESP_LOGI(TAG, "ADC pattern attenuation = %hhu", battery_monitor_adc_config.atten);
+        ESP_LOGI(TAG, "ADC bitwidth = %hhu", battery_monitor_adc_config.bitwidth);
+        ESP_LOGI(TAG, "ADC pattern unit = %hhu", adc1_init_config.unit_id);
+        ESP_LOGI(TAG, "ADC pattern channel = %hhu (GPIO NUMBER = %hhu)", battery_monitor_adc_channel, CONFIG_BATTERY_MON_ADC_GPIO_NUM);
+
+        status = adc_oneshot_config_channel(adc_handle, battery_monitor_adc_channel, &battery_monitor_adc_config);
+    }
+
+    if (ESP_OK == status)
+    {
+        adc_is_calibrated = adc_calibration_init(
+            adc1_init_config.unit_id, 
+            battery_monitor_adc_channel, 
+            battery_monitor_adc_config.atten, 
+            &battery_monitor_adc_calibration_handle
+        );
+    }
+
+    if (ESP_OK == status)
+    {
+        feedback_event_queue = feedback_event_queue_handle;
+
+        battery_monitor_timer = xTimerCreate(
+            "bat_mon",
+            pdMS_TO_TICKS(CONFIG_BATTERY_MONITOR_SAMPLE_PERIOD_MS),
+            pdTRUE,
+            NULL,
+            battery_monitor_timer_callback
+        );
+
+        if (NULL != battery_monitor_timer)
+        {
+            result = xTimerStart(battery_monitor_timer, pdMS_TO_TICKS(10));
+
+            if (pdFAIL == result)
+            {
+                ESP_LOGE(TAG, "Battery monitor timer start fail");
+                status = ESP_FAIL;
+            }
+        }
+        else
+        {
+            status = ESP_ERR_NO_MEM;
+        }
+    }
+
+    return status;
+}
+
+esp_err_t battery_monitor_deinit(void)
+{
+    esp_err_t status;
+
+    status = ESP_OK;
+
+    return status;
+}
+
+void battery_monitor_timer_callback(TimerHandle_t timer)
+{
+    esp_err_t status;
+    static int32_t previous_value_mv = LONG_MAX;
+    int32_t raw_conversion_value;
+    int32_t value_mv;
+
+    if (NULL != adc_handle)
+    {
+        status = adc_oneshot_read(adc_handle, battery_monitor_adc_channel, (int *) &raw_conversion_value);
+
+        if (ESP_OK == status)
+        {
+            ESP_LOGD(TAG, "ADC raw data = %ld", raw_conversion_value);
+
+            if (adc_is_calibrated)
+            {
+                status = adc_cali_raw_to_voltage(battery_monitor_adc_calibration_handle, raw_conversion_value, (int *) &value_mv);
+
+                if (ESP_OK == status)
+                {
+                    ESP_LOGD(TAG, "ADC calibrated and converted voltage = %ld mV", value_mv);
+
+                    if (CAN_ENTER_DEEP_SLEEP_ON_LOW_BATTERY && LONG_MAX != previous_value_mv)
+                    {
+                        if (CONFIG_BATTERY_MON_LOW_BATTERY_THRESHOLD_MV <= previous_value_mv && CONFIG_BATTERY_MON_LOW_BATTERY_THRESHOLD_MV > value_mv)
+                        {
+                            // El voltaje de la batería cayó de CONFIG_BATTERY_MON_LOW_BATTERY_THRESHOLD_MV.
+                            status = hmi_feedback_event_send(FEEDBACK_EVENT_LOW_BATTERY, FEEDBACK_SOURCE_SYSTEM, FEEDBACK_PRIORITY_NORMAL, (TickType_t) 0);
+
+                            if (ESP_OK != status)
+                            {
+                                ESP_LOGW(TAG, "send LOW BATTERY feedabck fail (%s)", esp_err_to_name(status));
+                            }
+                        }
+                        
+                        if (((int32_t) CONFIG_BATTERY_MON_CRITICAL_BATTERY_THRESHOLD_MV) > previous_value_mv && ((int32_t) CONFIG_BATTERY_MON_CRITICAL_BATTERY_THRESHOLD_MV) > value_mv)
+                        {
+                            // El voltaje de la batería cayó a través de CONFIG_BATTERY_MON_CRITICAL_BATTERY_THRESHOLD_MV.
+                            status = power_save_post_event(POWER_SAVE_EVT_BATTERY_CRITICAL, pdFALSE);
+
+                            if (ESP_OK != status)
+                            {
+                                ESP_LOGW(TAG, "send BATTERY CRITICAL event fail (%s)", esp_err_to_name(status));
+                            }
+                        }
+                        // else if (CONFIG_BATTERY_MON_CRITICAL_BATTERY_THRESHOLD_MV > previous_value_mv && CONFIG_BATTERY_MON_CRITICAL_BATTERY_THRESHOLD_MV <= value_mv)
+                        // {
+                        //     // El estado de carga de la batería ya no es crítico. 
+                        //     // El voltaje de la batería subió de CONFIG_BATTERY_MON_CRITICAL_BATTERY_THRESHOLD_MV.
+                        //     // Limpiar el evento de batería crítica.
+                        //     status = power_save_post_event(POWER_SAVE_EVT_BATTERY_CRITICAL, pdTRUE);
+
+                        //     if (ESP_OK != status)
+                        //     {
+                        //         ESP_LOGW(TAG, "send BATTERY NO LONGER CRITICAL event fail (%s)", esp_err_to_name(status));
+                        //     }
+                        // }
+                    }
+
+                    previous_value_mv = value_mv;
+                }
+            }
+        }
+        else
+        {
+            ESP_LOGW(TAG, "ADC read fail (%s)", esp_err_to_name(status));
+        }
+    }
+}
+
+bool adc_calibration_init(adc_unit_t unit_id, adc_channel_t channel, adc_atten_t attenuation, adc_cali_handle_t * out_calibration_handle)
+{
+    adc_cali_handle_t handle;
+    esp_err_t status;
+    bool calibrated;
+
+    calibrated = false;
+    status = ESP_OK;
+
+#if ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+    adc_cali_line_fitting_config_t line_fitting_config;
+#endif
+
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+    if (!calibrated)
+    {
+
+    }
+#endif
+
+#if ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+    if (!calibrated)
+    {
+        ESP_LOGI(TAG, "calibration scheme version = LINE_FITTING");
+        line_fitting_config = (adc_cali_line_fitting_config_t) {
+            .unit_id = unit_id,
+            .atten = attenuation,
+            .bitwidth = BATTERY_MONITOR_ADC_BIT_WIDTH
+        };
+
+        status = adc_cali_create_scheme_line_fitting(&line_fitting_config, &handle);
+
+        if (ESP_OK == status)
+        {
+            calibrated = true;
+        }
+    }
+#endif
+
+    if (ESP_OK == status)
+    {
+        *out_calibration_handle = handle;
+        ESP_LOGI(TAG, "Calibration success");
+    }
+    else if (ESP_ERR_NOT_SUPPORTED == status || !calibrated)
+    {
+        ESP_LOGW(TAG, "eFuse not burnt, skip software calibration");
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Calibration fail (invalid argument or not enough memory)");
+    }
+
+    return calibrated;
+}

--- a/components/battery_monitor/include/battery_monitor.h
+++ b/components/battery_monitor/include/battery_monitor.h
@@ -1,0 +1,46 @@
+#ifndef BATTERY_MONITOR_H_
+#define BATTERY_MONITOR_H_
+
+#include <esp_log.h>
+#include <esp_err.h>
+
+#include <hal/adc_types.h>
+#include <esp_adc/adc_oneshot.h>
+#include <esp_adc/adc_cali.h>
+#include <esp_adc/adc_cali_scheme.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/timers.h>
+#include <freertos/queue.h>
+
+#include "hmi.h"
+
+
+/**
+ * @brief Inicializa el monitor de estado de carga de la batería.
+ * 
+ * Cuando el estado de carga de la batería pasa por los umbrales configurados, el monitor
+ * de batería envía eventos de retroalimentación al usuario y de ahorro de energía (POWER_SAVE_EVT_BATTERY_CRITICAL). 
+ * 
+ * @note Este módulo usa ADC1 como una forma básica de detectar el voltaje actual de la batería. 
+ * 
+ * @param feedback_event_queue_handle referencia a la queue de eventos de retroalimentación.
+ * 
+ * @return - ESP_OK cuando inicializó correctamente el monitor de batería.
+ * @return - ESP_ERR_NO_MEM cuando no hay memoria suficiente memoria heap libre para los recursos del módulo.
+ * @return - ESP_ERR_INVALID_ARG cuando la configuración en kconfig tiene valores incorrectos.
+ * @return - ESP_FAIL cuando no pudo iniciar el software timer que controla el muestreo de la batería.
+ */
+esp_err_t battery_monitor_init(const QueueHandle_t feedback_event_queue_handle);
+
+
+/**
+ * @brief De-inicializa el monitor de estado de carga de la batería y libera los recursos asociados a él.
+ * 
+ * @return - ESP_OK cuando de-inicializó correctamente al módulo.
+ * @return - ESP_ERR_INVALID_STATE cuando el módulo estaba inicializado.
+ * @return - ESP_FAIL en cualquier otro error.
+ */
+esp_err_t battery_monitor_deinit(void);
+
+#endif /* BATTERY_MONITOR_H_ */

--- a/components/hmi/CMakeLists.txt
+++ b/components/hmi/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "hmi.c"
     INCLUDE_DIRS "include"
-    REQUIRES "driver" "freertos"
+    REQUIRES "driver" "freertos" "power_save"
 )

--- a/components/hmi/hmi.c
+++ b/components/hmi/hmi.c
@@ -211,6 +211,11 @@ esp_err_t hmi_power_button_init(void)
         status = gpio_isr_handler_add(CONFIG_HMI_POWER_BUTTON_PIN_NUMBER, hmi_button_gpio_isr_handler, (void *) CONFIG_HMI_POWER_BUTTON_PIN_NUMBER);
     }
 
+    if (ESP_OK == status)
+    {
+        status = gpio_intr_enable(CONFIG_HMI_POWER_BUTTON_PIN_NUMBER);
+    }
+
     return status;
 }
 

--- a/components/hmi/include/hmi.h
+++ b/components/hmi/include/hmi.h
@@ -42,6 +42,7 @@ typedef enum _feedback_source_t {
     FEEDBACK_SOURCE_PROXIMITY,
     FEEDBACK_SOURCE_NAVIGATION,
     FEEDBACK_SOURCE_OBJECT_DETECT,
+    FEEDBACK_SOURCE_SYSTEM,
     FEEDBACK_SOURCE_MAX,
 } feedback_source_t;
 
@@ -56,10 +57,13 @@ typedef struct _feedback_event_t {
  * 
  * @note Para que las interrupciones de GPIO funcionen, la aplicación debe invocar gpio_install_isr_service() antes de invocar hmi_init().
  * 
+ * @param feedback_event_queue_handle referencia a la queue que usará HMI para transmitir eventos de retroalimentación.
+ * 
  * @return - ESP_OK HMI fue inicializada correctamente.
+ * @return - ESP_ERR_INVALID_ARG si feedback_event_queue_handle es NULL.
  * @return - ESP_FAIL error durante la inicialización de HMI.
  */
-esp_err_t hmi_init(void);
+esp_err_t hmi_init(QueueHandle_t feedback_event_queue_handle);
 
 
 /**
@@ -73,5 +77,20 @@ esp_err_t hmi_init(void);
  * @return ESP_OK si la secuencia se reprodució correctamente.
  */
 esp_err_t hmi_buzzer_play_feedback_sequence(feedback_event_id_t event_id, TickType_t timeout_ticks);
+
+/**
+ * @brief Envía un evento de retroalimentación para que HMI lo comunique al usuario.
+ * 
+ * @param event_id identificador del evento de retroalimentación (FEEDBACK_EVENT_*).
+ * @param source fuente de la retroalimentación (FEEDBACK_SOURCE_*).
+ * @param priority prioridad de la retroalimentación (FEEDBACK_PRIORITY_*).
+ * @param timeout_ticks el número máximo de ticks que bloquea a la tarea si no hay espacio en la queue de eventos.
+ * 
+ * @return - ESP_OK si envió el evento de retroalimentación correctamente.
+ * @return - ESP_ERR_INVALID_STATE si HMI no está inicializado.
+ * @return - ESP_ERR_NO_MEM si no hay suficiente memoria para enviar el evento.
+ * @return - ESP_FAIL si no hay espacio en la queue de eventos. La tarea puede haber sido bloqueada hasta timeout_ticks.
+ */
+esp_err_t hmi_feedback_event_send(feedback_event_id_t event_id, feedback_source_t source, feedback_priority_t priority, TickType_t timeout_ticks);
 
 #endif /* HMI_H_ */

--- a/components/hmi/include/hmi.h
+++ b/components/hmi/include/hmi.h
@@ -12,6 +12,8 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
+#include "power_save.h"
+
 /**
  * Public structures and enumerations.
  */
@@ -52,8 +54,10 @@ typedef struct _feedback_event_t {
 /**
  * @brief Inicializa los botones y el buzzer del HMI.
  * 
- * @return ESP_OK - HMI fue inicializada correctamente.
- *         Cualquier otro valor - Error durante la inicialización de HMI.
+ * @note Para que las interrupciones de GPIO funcionen, la aplicación debe invocar gpio_install_isr_service() antes de invocar hmi_init().
+ * 
+ * @return - ESP_OK HMI fue inicializada correctamente.
+ * @return - ESP_FAIL error durante la inicialización de HMI.
  */
 esp_err_t hmi_init(void);
 

--- a/components/power_save/CMakeLists.txt
+++ b/components/power_save/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "power_save.c"
+    INCLUDE_DIRS "include"
+    REQUIRES "freertos" "esp_hw_support" "driver"
+)

--- a/components/power_save/Kconfig.projbuild
+++ b/components/power_save/Kconfig.projbuild
@@ -1,0 +1,8 @@
+menu "Power save"
+    config WAIT_BEFORE_DEEP_SLEEP_ENTER_MS
+        int
+        default 1000
+        prompt "Milliseconds to wait before entering deep sleep after conditions are met"
+        help
+            If deep sleep conditions are met, the power save module waits at least this number of milliseconds before entering sleep.        
+endmenu

--- a/components/power_save/include/power_save.h
+++ b/components/power_save/include/power_save.h
@@ -1,0 +1,87 @@
+#ifndef POWER_SAVE_H_
+#define POWER_SAVE_H_
+
+#include <esp_log.h>
+#include <esp_err.h>
+
+#include <esp_sleep.h>
+#include <driver/gpio.h>
+#include <driver/rtc_io.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+#include <freertos/timers.h>
+
+#define POWER_SAVE_EVT_ENTER            ((EventBits_t) (1u << 0u))
+#define POWER_SAVE_EVT_WOKE_FROM_SLEEP  ((EventBits_t) (1u << 1u))
+#define POWER_SAVE_EVT_LOW_BATTERY      ((EventBits_t) (1u << 2u))
+#define POWER_SAVE_EVT_USER_REQUEST     ((EventBits_t) (1u << 3u))
+#define POWER_SAVE_EVT_SENSOR_1_IDLE    ((EventBits_t) (1u << 4u))
+#define POWER_SAVE_EVT_SENSOR_2_IDLE    ((EventBits_t) (1u << 5u))
+#define POWER_SAVE_EVT_SENSOR_3_IDLE    ((EventBits_t) (1u << 6u))
+#define POWER_SAVE_EVT_SENSOR_4_IDLE    ((EventBits_t) (1u << 7u))
+
+
+/**
+ * @brief Inicializa el módulo de ahorro de energía, determina la causa del wakeup.
+ * 
+ * Debe invocarse power_save_init() antes de usar cualquier otra función del módulo
+ * de ahorro de energía.
+ * 
+ * @return - ESP_OK inicializó correctamente el módulo.
+ * @return - ESP_ERR_NO_MEM no hay memoria libre suficiente para inicializar el módulo.
+ * @return - ESP_FAIL en caso de algún otro error.
+ */
+esp_err_t power_save_init(void);
+
+/**
+ * @brief De-inicializa y libera los recursos usados por el módulo de ahorro de energía.
+ * 
+ * @return - ESP_OK liberó los recursos y desactivó el módulo de ahorro de energía.
+ * @return - ESP_ERR_INVALID_STATE el módulo de ahorro de energía no estaba inicializado.
+ * @return - ESP_FAIL en caso de algún otro error. 
+ */
+esp_err_t power_save_deinit(void);
+
+/**
+ * @brief Registra el número del GPIO que sirve para wakeup externo desde sueño profundo.
+ * 
+ * @param wakeup_pin el número de GPIO que despertará al mcu cuando el pin cambie a estado bajo.
+ * 
+ * @note En ESP32 base, wakeup_pin debe ser ESP32: 0, 2, 4, 12-15, 25-27, 32-39.
+ * 
+ * @return - ESP_OK si configuró correctamente el GPIO para despertar de sueño profundo.
+ * @return - ESP_FAIL en caso de algún otro error. 
+ */
+esp_err_t power_save_register_ext0_wakeup(gpio_num_t wakeup_pin);
+
+/**
+ * @brief Recupera el estado actual de los eventos del módulo de ahorro de energía.
+ * 
+ * No bloquea la tarea para esperar a un conjunto de bits específico.
+ * 
+ * @note No usar esta función desde una interrupción.
+ * 
+ * @param out_events referencia en donde almacenará el estado de los eventos.
+ * 
+ * @return - ESP_OK recuperó correctamente el estado de los eventos de ahorro de energía.
+ * @return - ESP_ERR_INVALID_STATE el módulo de ahorro de energía no estaba inicializado.
+ * @return - ESP_ERR_INVALID_ARG out_events es NULL.
+ * @return - ESP_FAIL en caso de algún otro error.
+ */
+esp_err_t power_save_events_pending(EventBits_t * const out_events);
+
+/**
+ * @brief Publica conjunto de eventos POWER_SAVE_*.
+ * 
+ * No bloquea la tarea.
+ * 
+ * @param event el conjunto de eventos de ahorro de energía.
+ * 
+ * @return - ESP_OK si actualizó correctamente el estado de los eventos de ahorro de energía.
+ * @return - ESP_ERR_INVALID_STATE el módulo de ahorro de energía no estaba inicializado.
+ * @return - ESP_FAIL en caso de algún otro error.
+ */
+esp_err_t power_save_post_event(const EventBits_t event);
+
+#endif /* POWER_SAVE_H_ */

--- a/components/power_save/include/power_save.h
+++ b/components/power_save/include/power_save.h
@@ -77,11 +77,29 @@ esp_err_t power_save_events_pending(EventBits_t * const out_events);
  * No bloquea la tarea.
  * 
  * @param event el conjunto de eventos de ahorro de energía.
+ * @param clear_bits si es pdTRUE, desactiva los eventos especificados en event. Si es pdFALSE, se activa los eventos.
  * 
  * @return - ESP_OK si actualizó correctamente el estado de los eventos de ahorro de energía.
  * @return - ESP_ERR_INVALID_STATE el módulo de ahorro de energía no estaba inicializado.
  * @return - ESP_FAIL en caso de algún otro error.
  */
-esp_err_t power_save_post_event(const EventBits_t event);
+esp_err_t power_save_post_event(const EventBits_t event, BaseType_t clear_bits);
+
+/**
+ * @brief Una versión de power_save_post_event() que puede invocarse desde una ISR.
+ * 
+ * Aunque el módulo de ahorro de energía no permite bloquear tareas según los eventos POWER_SAVE_EVT_*,
+ * debe usarse esta versión para modificar los eventos del módulo desde una ISR.
+ * 
+ * @param event el conjunto de eventos de ahorro de energía que activará o desactivará.
+ * @param clear_bits si es pdTRUE, desactiva los eventos especificados en event. Si es pdFALSE, se activa los eventos.
+ * @param pxHigherPriorityTaskWoken si es pdTRUE, la modificación de eventos desbloqueó una tarea de mayor prioridad. Tarea actual debería hacer yield.
+ * 
+ * @return - ESP_OK si actualizó correctamente el estado de los eventos de ahorro de energía.
+ * @return - ESP_ERR_INVALID_STATE el módulo de ahorro de energía no estaba inicializado.
+ * @return - ESP_ERR_INVALID_ARG si pxHigherPriorityTaskWoken es NULL.
+ * @return - ESP_FAIL en caso de algún otro error.
+ */
+esp_err_t power_save_post_event_from_isr(const EventBits_t event, BaseType_t clear_bits, BaseType_t * const pxHigherPriorityTaskWoken);
 
 #endif /* POWER_SAVE_H_ */

--- a/components/power_save/include/power_save.h
+++ b/components/power_save/include/power_save.h
@@ -14,7 +14,7 @@
 
 #define POWER_SAVE_EVT_ENTER            ((EventBits_t) (1u << 0u))
 #define POWER_SAVE_EVT_WOKE_FROM_SLEEP  ((EventBits_t) (1u << 1u))
-#define POWER_SAVE_EVT_LOW_BATTERY      ((EventBits_t) (1u << 2u))
+#define POWER_SAVE_EVT_BATTERY_CRITICAL ((EventBits_t) (1u << 2u))
 #define POWER_SAVE_EVT_USER_REQUEST     ((EventBits_t) (1u << 3u))
 #define POWER_SAVE_EVT_SENSOR_1_IDLE    ((EventBits_t) (1u << 4u))
 #define POWER_SAVE_EVT_SENSOR_2_IDLE    ((EventBits_t) (1u << 5u))

--- a/components/power_save/power_save.c
+++ b/components/power_save/power_save.c
@@ -1,0 +1,244 @@
+#include <time.h>
+#include <sys/time.h>
+
+#include "power_save.h"
+
+static const char * const TAG = "PWR_SAVE";
+
+static const TickType_t WAIT_BEFORE_DEEP_SLEEP_ENTER_TICKS = pdMS_TO_TICKS(CONFIG_WAIT_BEFORE_DEEP_SLEEP_ENTER_MS);
+static const EventBits_t POWER_SAVE_EVT_ALL_SENSORS_IDLE = (
+    POWER_SAVE_EVT_SENSOR_1_IDLE | POWER_SAVE_EVT_SENSOR_2_IDLE | 
+    POWER_SAVE_EVT_SENSOR_3_IDLE | POWER_SAVE_EVT_SENSOR_4_IDLE
+);
+
+static EventGroupHandle_t power_save_event_group;
+static TimerHandle_t sleep_activation_timer;
+
+static gpio_num_t ext0_wakeup_gpio = GPIO_NUM_MAX;
+static RTC_DATA_ATTR struct timeval sleep_enter_time;
+
+static void sleep_enter_timer_callback(TimerHandle_t timer);
+
+esp_err_t power_save_init(void)
+{
+    esp_err_t status;
+    struct timeval now;
+    esp_sleep_wakeup_cause_t wakeup_cause;
+    int ms_spent_in_sleep;
+
+    status = ESP_OK;
+    gettimeofday(&now, NULL);
+    ms_spent_in_sleep = (now.tv_sec - sleep_enter_time.tv_sec) * 1000 + (now.tv_usec - sleep_enter_time.tv_usec) / 1000;
+
+    // Inicializar recursos.
+    if (ESP_OK == status)
+    {
+        power_save_event_group = xEventGroupCreate();
+
+        if (NULL == power_save_event_group)
+        {
+            status = ESP_ERR_NO_MEM;
+        }
+    }
+
+    // Determinar la causa de reset (WAKEUP u otro tipo de reset)
+    wakeup_cause = esp_sleep_get_wakeup_cause();
+
+    switch (wakeup_cause)
+    {
+    case ESP_SLEEP_WAKEUP_EXT0:
+        ESP_LOGI(TAG, "Wake up from ext0, spent %d ms in deep sleep", ms_spent_in_sleep);
+        break;
+    case ESP_SLEEP_WAKEUP_UNDEFINED:
+        ESP_LOGI(TAG, "Not a deep sleep wakeup");
+        break;
+    default:
+        ESP_LOGI(TAG, "Unhandled wakeup cause: %u", wakeup_cause);
+        break;
+    }
+
+    if (ESP_OK == status)
+    {
+        xEventGroupSetBits(power_save_event_group, POWER_SAVE_EVT_WOKE_FROM_SLEEP);
+    }
+
+    return status;
+}
+
+esp_err_t power_save_deinit(void)
+{
+    esp_err_t status;
+
+    status = ESP_OK;
+    if (NULL == power_save_event_group)
+    {
+        status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (ESP_OK == status)
+    {
+        vEventGroupDelete(power_save_event_group);
+    }
+
+    return status;
+}
+
+esp_err_t power_save_register_ext0_wakeup(gpio_num_t wakeup_pin)
+{
+    esp_err_t status;
+
+    status = esp_sleep_enable_ext0_wakeup(wakeup_pin, 0);
+
+    if (ESP_OK == status)
+    {
+        ext0_wakeup_gpio = wakeup_pin;
+    }
+
+    return status;
+}
+
+esp_err_t power_save_events_pending(EventBits_t * const out_events)
+{
+    esp_err_t status;
+
+    status = ESP_OK;
+
+    if (NULL == out_events)
+    {
+        status = ESP_ERR_INVALID_ARG;
+    }
+
+    if (ESP_OK == status && NULL == power_save_event_group)
+    {
+        status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (ESP_OK == status)
+    {
+        *out_events = xEventGroupGetBits(power_save_event_group);
+    }
+
+    return status;
+}
+
+esp_err_t power_save_post_event(const EventBits_t event)
+{
+    EventBits_t power_save_event_bits;
+    BaseType_t should_enter_sleep;
+
+    esp_err_t status;
+    BaseType_t timer_modify_result;
+
+    status = ESP_OK;
+
+    if (NULL == power_save_event_group)
+    {
+        status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (ESP_OK == status)
+    {
+        power_save_event_bits = xEventGroupSetBits(power_save_event_group, event);
+        should_enter_sleep = (
+            POWER_SAVE_EVT_LOW_BATTERY & power_save_event_bits || 
+            POWER_SAVE_EVT_USER_REQUEST & power_save_event_bits || 
+            POWER_SAVE_EVT_ALL_SENSORS_IDLE == (POWER_SAVE_EVT_ALL_SENSORS_IDLE & power_save_event_bits)
+        );
+
+        if (should_enter_sleep && NULL == sleep_activation_timer)
+        {
+            sleep_activation_timer = xTimerCreate(
+                "sleep", 
+                WAIT_BEFORE_DEEP_SLEEP_ENTER_TICKS, 
+                pdFALSE, 
+                NULL, 
+                sleep_enter_timer_callback
+            );
+
+            if (NULL != sleep_activation_timer)
+            {
+                timer_modify_result = xTimerStart(sleep_activation_timer, pdMS_TO_TICKS(10));
+
+                if (pdFAIL == timer_modify_result)
+                {
+                    ESP_LOGE(TAG, "Sleep timer start fail");
+                }
+            }
+            else
+            {
+                status = ESP_ERR_NO_MEM;
+            }
+        }
+        else if (!should_enter_sleep && NULL != sleep_activation_timer)
+        {
+            timer_modify_result = xTimerStop(sleep_activation_timer, pdMS_TO_TICKS(10));
+
+            if (pdPASS == timer_modify_result)
+            {
+                timer_modify_result = xTimerDelete(sleep_activation_timer, pdMS_TO_TICKS(10));
+
+                if (pdPASS == timer_modify_result)
+                {
+                    sleep_activation_timer = NULL;
+                }
+                else
+                {
+                    ESP_LOGE(TAG, "Sleep timer delete fail");
+                }
+            }
+            else
+            {
+                ESP_LOGE(TAG, "Sleep timer stop fail");
+            }
+        }
+    }
+
+    return status;
+}
+
+void sleep_enter_timer_callback(TimerHandle_t timer)
+{
+    EventBits_t power_save_event_bits;
+    BaseType_t should_enter_sleep;
+    esp_err_t status;
+
+    if (NULL != power_save_event_group)
+    {
+        status = ESP_OK;
+        // Revisar si todavía se cumple al menos una de las tres condiciones para entrar en sueño profundo.
+        power_save_event_bits = xEventGroupGetBits(power_save_event_group);
+        should_enter_sleep = (
+            POWER_SAVE_EVT_LOW_BATTERY & power_save_event_bits || 
+            POWER_SAVE_EVT_USER_REQUEST & power_save_event_bits || 
+            POWER_SAVE_EVT_ALL_SENSORS_IDLE == (POWER_SAVE_EVT_ALL_SENSORS_IDLE & power_save_event_bits)
+        );
+
+        if (should_enter_sleep)
+        {
+            if (GPIO_NUM_MAX > ext0_wakeup_gpio)
+            {
+                status = rtc_gpio_pullup_dis(ext0_wakeup_gpio);
+
+                if (ESP_OK == status)
+                {
+                    status = rtc_gpio_pullup_en(ext0_wakeup_gpio);
+                }
+            }
+
+            if (ESP_OK == status)
+            {
+                ESP_LOGI(TAG, "Entering deep sleep");
+                gettimeofday(&sleep_enter_time, NULL);
+                esp_deep_sleep_start();
+            }
+            else
+            {
+                ESP_LOGW(TAG, "Enter deep sleep cancel (%s)", esp_err_to_name(status));
+            }
+        }
+    }
+    else
+    {
+        ESP_LOGW(TAG, "Did not enter sleep, power save event group is NULL");
+    }
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES "tf_mini_parser" "hmi" "imu"
+    REQUIRES "tf_mini_parser" "hmi" "imu" "power_save"
 )

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES "tf_mini_parser" "hmi" "imu" "power_save"
+    REQUIRES "tf_mini_parser" "hmi" "imu" "power_save" "battery_monitor"
 )

--- a/main/main.c
+++ b/main/main.c
@@ -14,6 +14,7 @@
 #include "hmi.h"
 #include "tf_mini_parser.h"
 #include "imu.h"
+#include "power_save.h"
 
 typedef struct _proximity_range_update_t {
     int8_t index_change;

--- a/main/main.c
+++ b/main/main.c
@@ -67,6 +67,11 @@ void app_main(void)
         status = gpio_install_isr_service(ESP_INTR_FLAG_EDGE);
     }
 
+    if (ESP_OK == status)
+    {
+        status = power_save_init();
+    }
+
     // Inicialización de queues de acceso "público".
     if (ESP_OK == status)
     {

--- a/main/main.c
+++ b/main/main.c
@@ -11,6 +11,7 @@
 
 #include <IQmathLib.h>
 
+#include "battery_monitor.h"
 #include "hmi.h"
 #include "tf_mini_parser.h"
 #include "imu.h"
@@ -49,9 +50,6 @@ static void hmi_task(void * pvParameters);
 
 static IRAM_ATTR void imu_isr(void * pvParameters); 
 
-static esp_err_t feedback_event_send(feedback_event_id_t event_id, feedback_source_t source, feedback_priority_t priority, TickType_t timeout_ticks);
-
-static QueueHandle_t feedback_event_queue;
 static TaskHandle_t distance_sensor_task_handle;
 
 void app_main(void)
@@ -59,12 +57,13 @@ void app_main(void)
     esp_err_t status;
     BaseType_t result;
     QueueHandle_t proximity_update_queue;
+    QueueHandle_t feedback_event_queue;
 
     status = ESP_OK;
 
     if (ESP_OK == status)
     {
-        status = gpio_install_isr_service(ESP_INTR_FLAG_EDGE);
+        status = gpio_install_isr_service(0);
     }
 
     if (ESP_OK == status)
@@ -82,6 +81,16 @@ void app_main(void)
         {
             status = ESP_ERR_NO_MEM;
             ESP_LOGW(TAG, "Create queue fail (%s)", esp_err_to_name(status));
+        }
+    }
+
+    if (ESP_OK == status)
+    {
+        status = battery_monitor_init(feedback_event_queue);
+
+        if (ESP_OK != status)
+        {
+            ESP_LOGE(TAG, "Battery monitor init fail (%s)", esp_err_to_name(status));
         }
     }
 
@@ -121,7 +130,7 @@ void app_main(void)
 
     if (ESP_OK == status)
     {
-        result = xTaskCreate(hmi_task, "hmi_task", 2048, NULL, 6, NULL);
+        result = xTaskCreate(hmi_task, "hmi_task", 2048, (void *) feedback_event_queue, 6, NULL);
 
         if (pdPASS != result)
         {
@@ -142,18 +151,26 @@ void app_main(void)
 
 void hmi_task(void * pvParameters)
 {
-    static const TickType_t FEEDBACK_RECEIVE_TIMEOUT_TICKS = pdMS_TO_TICKS(1000u);
+    static const TickType_t FEEDBACK_RECEIVE_TIMEOUT_TICKS = pdMS_TO_TICKS(100u);
     static const TickType_t BUZZER_CONTROL_TIMEOUT_TICKS = pdMS_TO_TICKS(100u);
 
     BaseType_t result;
     esp_err_t status;
+    QueueHandle_t feedback_event_queue;
+    EventBits_t power_save_events;
     feedback_event_t * feedback_event;
 
     status = ESP_OK;
 
+    feedback_event_queue = (QueueHandle_t) pvParameters;
+    if (NULL == feedback_event_queue)
+    {
+        status = ESP_ERR_INVALID_ARG;
+    }
+
     if (ESP_OK == status)
     {
-        status = hmi_init();
+        status = hmi_init(feedback_event_queue);
         ESP_LOGI(TAG, "hmi init status (%s)", esp_err_to_name(status));
     }
 
@@ -193,6 +210,25 @@ void hmi_task(void * pvParameters)
             else
             {
                 ESP_LOGD(TAG, "HMI task received no feedback events");
+            }
+
+            status = power_save_events_pending(&power_save_events);
+
+            if (ESP_OK == status)
+            {
+                if (POWER_SAVE_EVT_ENTER & power_save_events)
+                {
+                    status = hmi_feedback_event_send(FEEDBACK_EVENT_PWR_SAVE_ENTER, FEEDBACK_SOURCE_SYSTEM, FEEDBACK_PRIORITY_HIGH, (TickType_t) 0);
+
+                    if (ESP_OK != status)
+                    {
+                        ESP_LOGE(TAG, "Power off feedback send fail (%s)", esp_err_to_name(status));
+                    }
+                }
+            }
+            else
+            {
+                ESP_LOGW(TAG, "HMI task check power save events fail (%s)", esp_err_to_name(status));
             }
         }
     }
@@ -278,7 +314,7 @@ void proximity_task(void * pvParameters)
                     {
                         if (2u > notify_level)
                         {
-                            status = feedback_event_send(FEEDBACK_EVENT_STOP, FEEDBACK_SOURCE_PROXIMITY, FEEDBACK_PRIORITY_HIGH, SEND_FEEDBACK_EVENT_TIMEOUT_TICKS);
+                            status = hmi_feedback_event_send(FEEDBACK_EVENT_STOP, FEEDBACK_SOURCE_PROXIMITY, FEEDBACK_PRIORITY_HIGH, SEND_FEEDBACK_EVENT_TIMEOUT_TICKS);
 
                             if (ESP_OK == status)
                             {
@@ -296,7 +332,7 @@ void proximity_task(void * pvParameters)
                     }
                     else if (1u > notify_level)
                     {
-                        status = feedback_event_send(FEEDBACK_EVENT_STOP, FEEDBACK_SOURCE_PROXIMITY, FEEDBACK_PRIORITY_NORMAL, SEND_FEEDBACK_EVENT_TIMEOUT_TICKS);
+                        status = hmi_feedback_event_send(FEEDBACK_EVENT_STOP, FEEDBACK_SOURCE_PROXIMITY, FEEDBACK_PRIORITY_NORMAL, SEND_FEEDBACK_EVENT_TIMEOUT_TICKS);
 
                         if (ESP_OK == status)
                         {
@@ -308,14 +344,23 @@ void proximity_task(void * pvParameters)
                         }
                     }
                 }
-                else
+                else if (0u != notify_level)
                 {
-                    notify_level = 0u;
+                    status = hmi_feedback_event_send(FEEDBACK_EVENT_STRAIGHT, FEEDBACK_SOURCE_PROXIMITY, FEEDBACK_PRIORITY_NORMAL, SEND_FEEDBACK_EVENT_TIMEOUT_TICKS);
+
+                    if (ESP_OK == status)
+                    {
+                        notify_level = 0u;
+                    }
+                    else
+                    {
+                        ESP_LOGW(TAG, "Send feedback event fail (%s)", esp_err_to_name(status));
+                    }
                 }
             }
             else
             {
-                status = feedback_event_send(FEEDBACK_EVENT_SENSOR_ERROR, FEEDBACK_SOURCE_PROXIMITY, FEEDBACK_PRIORITY_NORMAL, SEND_FEEDBACK_EVENT_TIMEOUT_TICKS);
+                status = hmi_feedback_event_send(FEEDBACK_EVENT_SENSOR_ERROR, FEEDBACK_SOURCE_PROXIMITY, FEEDBACK_PRIORITY_NORMAL, SEND_FEEDBACK_EVENT_TIMEOUT_TICKS);
 
                 if (ESP_OK != status)
                 {
@@ -392,6 +437,10 @@ void distance_sensor_task(void * pvParameters)
     if (ESP_OK == status)
     {
         status = imu_init(&imu_handle, imu_isr);
+        if (ESP_FAIL == status)
+        {
+            status = ESP_OK;
+        }
     }
 
     if (ESP_OK != status)
@@ -557,13 +606,13 @@ void object_detection_task(void * pvParameters)
             {
                 ESP_LOGI(TAG, "Test object detected");
 
-                status = feedback_event_send(FEEDBACK_EVENT_STOP, FEEDBACK_SOURCE_OBJECT_DETECT, FEEDBACK_PRIORITY_NORMAL, SEND_OBJECT_DETECT_EVENT_TIMEOUT_TICKS);
+                status = hmi_feedback_event_send(FEEDBACK_EVENT_STOP, FEEDBACK_SOURCE_OBJECT_DETECT, FEEDBACK_PRIORITY_NORMAL, SEND_OBJECT_DETECT_EVENT_TIMEOUT_TICKS);
             }
             else
             {
                 ESP_LOGI(TAG, "Test object no longer detected");
 
-                status = feedback_event_send(FEEDBACK_EVENT_STRAIGHT, FEEDBACK_SOURCE_OBJECT_DETECT, FEEDBACK_PRIORITY_LOW, SEND_OBJECT_DETECT_EVENT_TIMEOUT_TICKS);
+                status = hmi_feedback_event_send(FEEDBACK_EVENT_STRAIGHT, FEEDBACK_SOURCE_OBJECT_DETECT, FEEDBACK_PRIORITY_LOW, SEND_OBJECT_DETECT_EVENT_TIMEOUT_TICKS);
             }
 
             if (ESP_OK != status)
@@ -599,48 +648,4 @@ void imu_isr(void * pvParameters)
     {
         portYIELD_FROM_ISR();
     }
-}
-
-esp_err_t feedback_event_send(feedback_event_id_t event_id, feedback_source_t source, feedback_priority_t priority, TickType_t timeout_ticks)
-{
-    esp_err_t status;
-    BaseType_t result;
-    feedback_event_t * feedback_event;
-
-    if (NULL != feedback_event_queue)
-    {
-        status = ESP_OK;
-    }
-    else
-    {
-        status = ESP_ERR_INVALID_STATE;
-    }
-
-    if (status == ESP_OK)
-    {
-        feedback_event = (feedback_event_t *) malloc(sizeof(feedback_event_t));
-
-        if (NULL == feedback_event)
-        {
-            status = ESP_ERR_NO_MEM;
-        }
-    }
-
-    if (ESP_OK == status)
-    {
-        *feedback_event = (feedback_event_t) {
-            .id = event_id,
-            .source = source,
-            .priority = priority,
-        };
-
-        result = xQueueSendToBack(feedback_event_queue, (void *) &feedback_event, timeout_ticks);
-
-        if (pdFAIL == result)
-        {
-            status = ESP_FAIL;
-        }
-    }
-
-    return status;
 }


### PR DESCRIPTION
Los cambios incluyen:

- Módulo `power save` para controlar la entrada y salida de modo de sueño profundo.
- Módulo `battery monitor` para monitoreo del estado de carga de la batería. Por simplicidad, monitorea el voltaje de la batería con un divisor de voltaje.
- Soporte en HMI para un botón que permite activar y desactivar el sueño profundo.